### PR TITLE
[feat] Add ftp feature as docker container

### DIFF
--- a/ninety-nine.yml
+++ b/ninety-nine.yml
@@ -1,0 +1,18 @@
+version: '3'
+
+services:
+  ftpd_server:
+    image: stilliard/pure-ftpd
+    container_name: pure-ftpd
+    ports:
+      - "21:21"
+      - "30000-30009:30000-30009"
+    volumes:
+      - "/tmp/data-ftp:/home/username/"
+      - "/tmp/passwd-ftp:/etc/pure-ftpd/passwd"
+    environment:
+      PUBLICHOST: "localhost"
+      FTP_USER_NAME: ninetynine
+      FTP_USER_PASS: ninetynine-rules
+      FTP_USER_HOME: /home/username
+    restart: always


### PR DESCRIPTION
 * Docker compose initial file
 * Add ftp container using pure-ftpd (https://www.pureftpd.org/project/pure-ftpd)
 * Image obtained from https://github.com/stilliard/docker-pure-ftpd
 * Add initial (and unique) user ninety-nine in ftp server