### PR TITLE
[fix] Change the way to build docker image and push directly using gr…

### DIFF
--- a/TransferFTPUploader/Dockerfile
+++ b/TransferFTPUploader/Dockerfile
@@ -1,5 +1,4 @@
 FROM openjdk:12-jdk-alpine
 VOLUME /tmp
-ARG JAR_FILE=build/libs/TransferFTPUploader.jar
-ADD ${JAR_FILE} app.jar
-ENTRYPOINT exec java ${JAVA_OPTS} -jar /app.jar
+COPY TransferFTPUploader.jar TransferFTPUploader.jar
+ENTRYPOINT exec java ${JAVA_OPTS} -jar TransferFTPUploader.jar

--- a/TransferFTPUploader/build.gradle.kts
+++ b/TransferFTPUploader/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("java")
     id("org.springframework.boot") version "2.3.3.RELEASE"
     id("io.spring.dependency-management") version "1.0.10.RELEASE"
+    id("com.palantir.docker") version "0.25.0"
     kotlin("jvm") version "1.3.72"
     kotlin("plugin.spring") version "1.3.72"
 }
@@ -15,7 +16,13 @@ java {
 }
 
 group = "com.ninety.nine"
-version = "1.0-SNAPSHOT"
+version = "1.0.0"
+
+docker {
+    name = "transferuploader:$version"
+    this.tag("DockerHub","jtejedor/ninety-nine:$version-transferuploader")
+    this.files(tasks.bootJar.get().outputs)
+}
 
 repositories {
     mavenCentral()

--- a/ninety-nine.yml
+++ b/ninety-nine.yml
@@ -21,7 +21,7 @@ services:
     restart: always
 
   transferuploader:
-    image: transferuploader
+    image: jtejedor/ninety-nine:1.0.0-transferuploader
     depends_on:
       - ftpd_server
     links:


### PR DESCRIPTION
### [fix] Change the way to build docker image and push directly using gradle

* Change tag-name image to get directly image from docker hub ninety-nine repository
* Add palantir docker plugin
* Build and push transferftpuploader image to docker hub using gradle
* Change Dockerfile to simplify and adapt to the new push